### PR TITLE
Updated Aether Integration

### DIFF
--- a/src/main/java/top/theillusivec4/colytra/integration/AetherIntegration.java
+++ b/src/main/java/top/theillusivec4/colytra/integration/AetherIntegration.java
@@ -7,9 +7,12 @@ import top.theillusivec4.curios.api.CuriosApi;
 public class AetherIntegration {
 
   public static void checkCape(RenderElytraEvent evt) {
-    CuriosApi.getCuriosHelper()
-        .findEquippedCurio(stack -> stack.getItem() instanceof CapeItem, evt.getPlayer()).ifPresent(
-        triple -> evt
-            .setResourceLocation(((CapeItem) triple.getRight().getItem()).getCapeTexture()));
+    CuriosApi.getCuriosHelper().findEquippedCurio((item) -> item.getItem() instanceof CapeItem, evt.getPlayer()).ifPresent(triple ->
+            CuriosApi.getCuriosHelper().getCuriosHandler(evt.getPlayer()).ifPresent(handler -> handler.getStacksHandler(triple.getLeft()).ifPresent(stacksHandler -> {
+                CapeItem cape = (CapeItem) triple.getRight().getItem();
+                if (cape.getCapeTexture() != null && stacksHandler.getRenders().get(triple.getMiddle())) {
+                    evt.setResourceLocation(cape.getCapeTexture());
+                }
+            })));
   }
 }


### PR DESCRIPTION
Updates the `AetherIntegration` class based on recent changes to Aether's conditions for how cape skins are applied to elytras: If the cape is toggled to not render, the cape's elytra skin will also not render.