### PR TITLE
Fixing mending behavior

### DIFF
--- a/src/main/java/top/theillusivec4/colytra/common/CommonEventHandler.java
+++ b/src/main/java/top/theillusivec4/colytra/common/CommonEventHandler.java
@@ -76,6 +76,7 @@ public class CommonEventHandler {
       if (i <= 0) return; // no mending happens
       xpOrb.xpValue -= durabilityToXp(i);
       elytraStack.setDamage(elytraStack.getDamage() - i);
+      ElytraNBT.setElytra(chestStack, elytraStack); // write back NBT
 
       if (xpOrb.xpValue > 0) {
         player.giveExperiencePoints(xpOrb.xpValue);

--- a/src/main/java/top/theillusivec4/colytra/common/CommonEventHandler.java
+++ b/src/main/java/top/theillusivec4/colytra/common/CommonEventHandler.java
@@ -67,13 +67,13 @@ public class CommonEventHandler {
         || EnchantmentHelper.getEnchantmentLevel(Enchantments.MENDING, elytraStack) <= 0) {
       return;
     }
-    evt.setCanceled(true);
     ExperienceOrbEntity xpOrb = evt.getOrb();
 
     if (xpOrb.delayBeforeCanPickup == 0 && player.xpCooldown == 0) {
       player.xpCooldown = 2;
       player.onItemPickup(xpOrb, 1);
       int i = Math.min(xpToDurability(xpOrb.xpValue), elytraStack.getDamage());
+      if (i <= 0) return; // no mending happens
       xpOrb.xpValue -= durabilityToXp(i);
       elytraStack.setDamage(elytraStack.getDamage() - i);
 
@@ -82,6 +82,7 @@ public class CommonEventHandler {
       }
 
       xpOrb.remove();
+      evt.setCanceled(true); // only cancel when mending happens
     }
   }
 


### PR DESCRIPTION
current version of the mod causes all equipments with mending enchantment not working  
there're 2 parts of this bug in function `CommonEventHandler.handleColytraMending`:
1. the `onPlayerXPPickUp` event is hooked and cancelled before elytra mending actually happens
2. after the extracted elytra is mended, the NBT isn't set back into the chestplate (like what happens in `handleColytraRepair`)

I made a small fix about this